### PR TITLE
Make Parser.init public

### DIFF
--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -28,8 +28,8 @@ public func token<T: Equatable>(_ token: T) -> Parser<T, T> {
 }
 
 /** Match several tokens in a row. */
-public func tokens <T: Equatable, C: Collection> (_ xs: C) -> Parser<T,C> where C.Iterator.Element == T {
-    let length = xs.count as! Int
+public func tokens <T: Equatable, C: Collection> (_ xs: C) -> Parser<T,C> where C.Iterator.Element == T, C.IndexDistance == Int {
+    let length = xs.count
     return count(length, any()) >>- { parsedtokens in
         return parsedtokens.elementsEqual(xs) ? pure(xs) : fail(.Mismatch(AnyCollection(parsedtokens), String(describing:xs), String(describing:parsedtokens)))
     }
@@ -37,7 +37,7 @@ public func tokens <T: Equatable, C: Collection> (_ xs: C) -> Parser<T,C> where 
 
 /** Return whatever the next token is. */
 public func any <T> () -> Parser<T,T> {
-    return satisfy(expect: "anything") { T in true }
+    return satisfy(expect: "anything") { _ in true }
 }
 
 /** Try parser, if it fails return 'otherwise' without consuming input. */
@@ -125,7 +125,7 @@ public func oneOf <T: Equatable, C: Collection> (_ collection: C) -> Parser<T,T>
 
 /** Succeed if the next token is _not_ in the provided collection. */
 public func noneOf <T: Equatable, C: Collection> (_ collection: C) -> Parser<T,T> where C.Iterator.Element == T {
-    return satisfy(expect: "something not in '\(String(describing:collection))'") { !collection.contains($0) }
+    return satisfy(expect: "something not in '\(collection)'") { !collection.contains($0) }
 }
 
 /** Match anything but this. */

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -9,16 +9,16 @@ public struct Parser<Token, Output> {
 }
 
 public func satisfy<T>
-    (expect: String, condition: @escaping (T) -> Bool) -> Parser<T, T> {
+    (expect: @autoclosure @escaping () -> String, condition: @escaping (T) -> Bool) -> Parser<T, T> {
     return Parser { input in
         if let next = input.first {
             if condition(next) {
                 return (next, input.dropFirst())
             } else {
-                throw ParseError.Mismatch(input, expect, String(describing:next))
+                throw ParseError.Mismatch(input, expect(), String(describing:next))
             }
         } else {
-            throw ParseError.Mismatch(input, expect, "EOF")
+            throw ParseError.Mismatch(input, expect(), "EOF")
         }
     }
 }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -1,6 +1,11 @@
 // would've liked a generic typealias here.
 public struct Parser<Token, Output> {
-    public let parse: (AnyCollection<Token>) throws -> (output: Output, remainder: AnyCollection<Token>)
+    public typealias ParseFunction = (AnyCollection<Token>) throws -> (output: Output, remainder: AnyCollection<Token>)
+    public let parse: ParseFunction
+
+    public init( parse: @escaping ParseFunction ) {
+      self.parse = parse
+    }
 }
 
 public func satisfy<T>

--- a/Sources/StringParser.swift
+++ b/Sources/StringParser.swift
@@ -70,18 +70,16 @@ public func count <T> (_ r: Range<Int>, _ p: Parser<T,Character>) -> Parser<T,St
  - note: consumes either the full string or nothing, even on a partial match.
  */
 public func string (_ s: String) -> Parser<Character, String> {
-    let s2 = AnyCollection(s.characters)
-
     let count = s.characters.count
     return Parser { input in
         guard input.startIndex < input.endIndex else {
             throw ParseError.Mismatch(input, s, "EOF")
         }
-        guard let endIndex = input.index(input.startIndex, offsetBy: IntMax(count), limitedBy: input.endIndex) else {
+        guard let endIndex = input.index(input.startIndex, offsetBy:IntMax(count), limitedBy: input.endIndex) else {
             throw ParseError.Mismatch(input, s, String(input))
         }
         let next = input[input.startIndex..<endIndex]
-        if s2 == next {
+        if s.characters.elementsEqual(next) {
             return (s, input.dropFirst(count))
         } else {
             throw ParseError.Mismatch(input, s, String(next))
@@ -107,17 +105,17 @@ public func noneOf (_ s: String) -> Parser<Character,Character> {
  - note: consumes only produced characters
  */
 public func noneOf(_ strings: [String]) -> Parser<Character, Character> {
-    let strings = strings.map { ($0, AnyCollection($0.characters)) }
+    let strings = strings.map { ($0, $0.characters) }
     return Parser { input in
         guard let next = input.first else {
-            throw ParseError.Mismatch(input, "anything but \(string)", "EOF")
+            throw ParseError.Mismatch(input, "anything but \(strings)", "EOF")
         }
         for (string, characters) in strings {
             guard characters.first == next else { continue }
             let endIndex = input.index(input.startIndex, offsetBy: IntMax(characters.count))
             guard endIndex <= input.endIndex else { continue }
             let peek = input[input.startIndex..<endIndex]
-            if peek == characters { throw ParseError.Mismatch(input, "anything but \(string)", string) }
+            if characters.elementsEqual(peek) { throw ParseError.Mismatch(input, "anything but \(string)", string) }
         }
         return (next, input.dropFirst())
     }


### PR DESCRIPTION
So I ran into a badly diagnosed error that stumped me for most of the day.

The compiler-generated default constructor is apparently not, by default, `public`.  So it was impossible to generate a `Parser` object outside of the FootlessParser module.

d456c0a fixes that issue.

Also included are a couple other commits with some miscellaneous cleanups.