### PR TITLE
Bug fix and CocoaPods support

### DIFF
--- a/FootlessParser.podspec
+++ b/FootlessParser.podspec
@@ -1,13 +1,12 @@
 Pod::Spec.new do |s|
-  s.name         = "FootlessParser"
-  s.version      = "1.0"
-  s.summary      = "A simple parser combinator written in Swift"
-  s.description  = "FootlessParser is a simple and pretty naive implementation of a parser combinator in Swift. It enables infinite lookahead, non-ambiguous parsing with error reporting."
-  s.homepage     = "https://github.com/kareman/FootlessParser"
-  s.license      = { :type => "MIT", :file => "LICENSE.txt" }
-  s.author             = { "Kare Morstol" => "kare@nottoobadsoftware.com" }
-  s.source       = { :git => "https://github.com/kareman/FootlessParser.git", :tag => "1.0.0" }
-  s.source_files  = "Sources/*.swift"
-  # Swift is not avalible on > 10.10
-  s.osx.deployment_target  = "10.10"
+  s.name         = 'FootlessParser'
+  s.version      = '1.0'
+  s.summary      = 'A simple parser combinator written in Swift'
+  s.description  = 'FootlessParser is a simple and pretty naive implementation of a parser combinator in Swift. It enables infinite lookahead, non-ambiguous parsing with error reporting.'
+  s.homepage     = 'https://github.com/kareman/FootlessParser'
+  s.license      = { type: 'MIT', file: 'LICENSE.txt' }
+  s.author = { 'Kare Morstol' => 'kare@nottoobadsoftware.com' }
+  s.source = { git: 'https://github.com/kareman/FootlessParser.git', branch: 'swift3.0' }
+  s.source_files = 'Sources/*.swift'
+  s.osx.deployment_target = '10.10'
 end

--- a/FootlessParser.podspec
+++ b/FootlessParser.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "FootlessParser"
+  s.version      = "1.0"
+  s.summary      = "A simple parser combinator written in Swift"
+  s.description  = "FootlessParser is a simple and pretty naive implementation of a parser combinator in Swift. It enables infinite lookahead, non-ambiguous parsing with error reporting."
+  s.homepage     = "https://github.com/kareman/FootlessParser"
+  s.license      = { :type => "MIT", :file => "LICENSE.txt" }
+  s.author             = { "Kare Morstol" => "kare@nottoobadsoftware.com" }
+  s.source       = { :git => "https://github.com/kareman/FootlessParser.git", :tag => "1.0.0" }
+  s.source_files  = "Sources/*.swift"
+  # Swift is not avalible on > 10.10
+  s.osx.deployment_target  = "10.10"
+end

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ FootlessParser is a simple and pretty naive implementation of a parser combinato
 
 There is [a series of blog posts about the development](http://blog.nottoobadsoftware.com/footlessparser/) and [documentation from the source code](http://kareman.github.io/FootlessParser/).
 
-### Introduction
+## Introduction
 
 In short, FootlessParser lets you define parsers like this:
 
@@ -20,50 +20,53 @@ let parser = function1 <^> parser1 <*> parser2 <|> parser3
 
 `parser` will pass the input to `parser1` followed by `parser2`, pass their results to `function1` and return its result. If that fails it will pass the original input to `parser3` and return its result.
 
-### Definitions
+## Definitions
 
-##### Parser
+### Parser
+
 A function which takes some input (a sequence of tokens) and returns either the output and the remaining unparsed part of the input, or an error description if it fails.
 
-##### Token
+### Token
+
 A single item from the input. Like a character from a string, an element from an array or a string from a list of command line arguments.
 
-##### Parser Input
+### Parser Input
+
 Most often text, but can also be an array or really any collection of anything, provided it conforms to CollectionType.
 
-### Parsers
+## Parsers
 
-The general idea is to combine very simple parsers into more complex ones. So `char("a")`  creates a parser which checks if the next token from the input is an “a”. If it is it returns that “a”, otherwise it returns an error. You can then use operators and functions like `zeroOrMore` and `optional` to create ever more complex parsers. For more check out [the full list of functions](http://kareman.github.io/FootlessParser/Functions.html).
+The general idea is to combine very simple parsers into more complex ones. So `char("a")` creates a parser which checks if the next token from the input is an "a". If it is it returns that "a", otherwise it returns an error. You can then use operators and functions like `zeroOrMore` and `optional` to create ever more complex parsers. For more check out [the full list of functions](http://kareman.github.io/FootlessParser/Functions.html).
 
-### Operators
+## Operators
 
-##### <^> (map)
+### <^> (map)
 
-`function <^> parser1` creates a new parser which runs parser1. If it succeeds it passes the output to `function` and returns the result.
+`function <^> parser1` creates a new parser which runs parser1\. If it succeeds it passes the output to `function` and returns the result.
 
-##### <*> (apply)
+### <*> (apply)
 
-`function <^> parser1 <*> parser2` creates a new parser which first runs parser1. If it succeeds it runs parser2. If that also succeeds it passes both outputs to `function` and returns the result.
+`function <^> parser1 <*> parser2` creates a new parser which first runs parser1\. If it succeeds it runs parser2\. If that also succeeds it passes both outputs to `function` and returns the result.
 
 The <*> operator requires its left parser to return a function and is normally used together with <^>. `function` must take 2 parameters of the correct types, and it must be [curried](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Declarations.html#//apple_ref/doc/uid/TP40014097-CH34-ID363), like this:
 
 ```swift
-func function (a:A)(b:B) -> C 
+func function (a:A)(b:B) -> C
 ```
 
 This is because <*> returns the output of 2 parsers and it doesn't know what to do with them. If you want them returned in a tuple, an array or e.g. added together you can do so in the function before <^> .
 
 If there are 3 parsers and 2 <*> the function must take 3 parameters, and so on.
 
-##### <* 
+### <*
 
 The same as the <*> above, except it discards the result of the parser to its right. Since it only returns one output it doesn't need to be used together with <^> . But you can of course if you want the output converted to something else.
 
-##### *>
+### *>
 
 The same as <* , but discards the result of the parser to its left.
 
-##### <|> (choice)
+### <|> (choice)
 
 ```
 parser1 <|> parser2 <|> parser3
@@ -71,17 +74,17 @@ parser1 <|> parser2 <|> parser3
 
 This operator tries all the parsers in order and returns the result of the first one that succeeds.
 
-##### >>- (flatmap)
+### >>- (flatmap)
 
 ```
 parser1 >>- ( o -> parser2 )
 ```
 
-This does the same as the flatmap functions in the Swift Standard Library. It creates a new parser which first tries parser1. If it fails it returns the error, if it succeeds it passes the output to the function which uses it to create parser2. It then runs parser2 and returns its output or error.
+This does the same as the flatmap functions in the Swift Standard Library. It creates a new parser which first tries parser1\. If it fails it returns the error, if it succeeds it passes the output to the function which uses it to create parser2\. It then runs parser2 and returns its output or error.
 
-### Example
+## Example
 
-#### [CSV](http://www.computerhope.com/jargon/c/csv.htm) parser
+### [CSV](http://www.computerhope.com/jargon/c/csv.htm) parser
 
 ```swift
 let delimiter = "," as Character
@@ -89,7 +92,7 @@ let quote = "\"" as Character
 let newline = "\n" as Character
 
 let cell = char(quote) *> zeroOrMore(not(quote)) <* char(quote)
-	<|> zeroOrMore(noneOf([delimiter, newline]))
+    <|> zeroOrMore(noneOf([delimiter, newline]))
 
 let row = extend <^> cell <*> zeroOrMore( char(delimiter) *> cell ) <* char(newline)
 let csvparser = zeroOrMore(row)
@@ -97,25 +100,24 @@ let csvparser = zeroOrMore(row)
 
 Here a cell (or field) either:
 
-- begins with a ", then contains anything, including commas, tabs and newlines, and ends with a " (both quotes are discarded) 
+- begins with a ", then contains anything, including commas, tabs and newlines, and ends with a " (both quotes are discarded)
 - or is unquoted and contains anything but a comma or a newline.
 
-Each row then consists of one or more cells, separated by commas and ended by a newline. The `extend` function joins the cells together into an array. 
-Finally the `csvparser` collects zero or more rows into an array.
+Each row then consists of one or more cells, separated by commas and ended by a newline. The `extend` function joins the cells together into an array. Finally the `csvparser` collects zero or more rows into an array.
 
 To perform the actual parsing:
 
 ```swift
 do {
-	let output = try parse(csvparser, csvtext)
-	// output is an array of all the rows, 
-	// where each row is an array of all its cells.
+    let output = try parse(csvparser, csvtext)
+    // output is an array of all the rows,
+    // where each row is an array of all its cells.
 } catch {
 
 }
 ```
 
-#### Recursive expression
+### Recursive expression
 
 ```swift
 func add (a:Int)(b:Int) -> Int { return a + b }
@@ -137,13 +139,13 @@ do {
 } catch { }
 ```
 
-`expression` parses input like "12", "1+2+3", "(1+2)", "12*3+1" and "12*(3+1)" and returns the result as an Int.
+`expression` parses input like "12", "1+2+3", "(1+2)", "12_3+1" and "12_(3+1)" and returns the result as an Int.
 
 All parsers which refer to themselves directly or indirectly must be pre-declared as variable implicitly unwrapped optionals (`var expression: Parser<Character, Int>!`). And to avoid infinte recursion the definitions must use the `lazy` function.
 
-### Installation
+## Installation
 
-#### Using [Carthage](https://github.com/Carthage/Carthage)
+### Using [Carthage](https://github.com/Carthage/Carthage)
 
 ```
 github "kareman/FootlessParser"
@@ -152,5 +154,15 @@ github "kareman/FootlessParser"
 Then run `carthage update`.
 
 Follow the current instructions in [Carthage's README][carthage-installation] for up to date installation instructions.
+
+### Using [CocoaPods](https://cocoapods.org/)
+
+Add `FootlessParser` to your `Podfile` file.
+
+```
+pod "FootlessParser", git: "https://github.com/kareman/FootlessParser.git", branch: "swift3.0"
+```
+
+Then run `pod install` to install it.
 
 [carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ do {
 } catch { }
 ```
 
-`expression` parses input like "12", "1+2+3", "(1+2)", "12_3+1" and "12_(3+1)" and returns the result as an Int.
+`expression` parses input like `"12"`, `"1+2+3"`, `"(1+2)"`, `"12*3+1"` and `"12*(3+1)"` and returns the result as an Int.
 
 All parsers which refer to themselves directly or indirectly must be pre-declared as variable implicitly unwrapped optionals (`var expression: Parser<Character, Int>!`). And to avoid infinte recursion the definitions must use the `lazy` function.
 

--- a/Sources/StringParser.swift
+++ b/Sources/StringParser.swift
@@ -64,7 +64,7 @@ public func count <T> (_ r: Range<Int>, _ p: Parser<T,Character>) -> Parser<T,St
     return extend <^> count(r.lowerBound, p) <*> ( count(r.count-1, p) <|> zeroOrMore(p) )
 }
 
-/** 
+/**
  Match a string
  - parameter: string to match
  - note: consumes either the full string or nothing, even on a partial match.
@@ -112,7 +112,9 @@ public func noneOf(_ strings: [String]) -> Parser<Character, Character> {
         }
         for (string, characters) in strings {
             guard characters.first == next else { continue }
-            let endIndex = input.index(input.startIndex, offsetBy: IntMax(characters.count))
+            let offset = IntMax(characters.count)
+            guard IntMax(input.count) >= offset else { continue }
+            let endIndex = input.index(input.startIndex, offsetBy: offset)
             guard endIndex <= input.endIndex else { continue }
             let peek = input[input.startIndex..<endIndex]
             if characters.elementsEqual(peek) { throw ParseError.Mismatch(input, "anything but \(string)", string) }

--- a/Tests/FootlessParserTests/StringParser_Tests.swift
+++ b/Tests/FootlessParserTests/StringParser_Tests.swift
@@ -22,6 +22,14 @@ class StringParser_Tests: XCTestCase {
 		XCTAssert(input == [], "Input should be empty")
 	}
 
+  func testOffsetForNoneOf () {
+    let input = "AB"
+    let parser = zeroOrMore(noneOf(["BC"]))
+		// fatal error: cannot increment beyond endIndex
+    let _ = try! parser.parse(AnyCollection(input.characters))
+		assertParseSucceeds(parser, input, result: "AB")
+  }
+
 	func testOneOrMoreParserForCharacters () {
 		let parser = oneOrMore(char("a"))
 
@@ -88,5 +96,6 @@ extension StringParser_Tests {
 		("testStringCountRangeParser", testStringCountRangeParser),
 		("testNoneOfStrings", testNoneOfStrings),
 		("testString", testString),
+		("testOffsetForNoneOf", testOffsetForNoneOf)
 		]
 }


### PR DESCRIPTION
Added support for CocoaPods and fixed a bug. Added a test that verifies the bug. Run `pod lib lint` on your system to verify the CocoaPod spec. Don't forget to update the branch in the README when you merge your `swift3.0` branch with `master` as its currently pointing to `swift3.0`.

EDIT: I see now that Atom, my editor went ahead and normalized the README after saving the document.  Let me know if you want me to revert it back to how it looked before.

Awesome work btw. I'm currently using Footless here: [App/BitBar/Parser/Parser.swift @ github.com/oleander/bitbar](https://github.com/oleander/bitbar/blob/swift/App/BitBar/Parser/Parser.swift)