### PR TITLE
Fix exhaust stack & make better performance at oneOrMore parser

### DIFF
--- a/Sources/StringParser.swift
+++ b/Sources/StringParser.swift
@@ -26,7 +26,7 @@ public func extend (_ a: Character) -> (String) -> String {
 
 /** Apply character parser once, then repeat until it fails. Returns a string. */
 public func oneOrMore <T> (_ p: Parser<T, Character>) -> Parser<T, String> {
-    return extend <^> p <*> optional( lazy(oneOrMore(p)), otherwise:"" )
+    return { (cs: [Character]) in String(cs) } <^> oneOrMore(p)
 }
 
 /** Repeat character parser until it fails. Returns a string. */


### PR DESCRIPTION
I found that `Character -> String` version of `oneOrMore` parser can crash by exhausting stack.
It seems to be related to recursive call with `lazy`.
This fix actually uses the generic version. Therefore it's naive but should work in better performance without crashes 😕

**Reproduce:**

* change oneOrMore test input with large number such as **10000** and do test

https://github.com/kareman/FootlessParser/blob/8792f4e4e809e943d0f8dcda25b82058e8eb00cf/Tests/FootlessParserTests/PerformanceTests.swift#L49-L51

**Analysis:**

Print debugging `Thread.callStackSymbols.count` shows an increase as parsing progress before this fix. With this fix, the stack depth does not increase.

**Example use case:**

Parsing Server Sent Events format requires parsing payload characters until newline. Sometimes it's large single-line JSON and can cause parser crash on runtime.

e.g. https://github.com/banjun/ReactiveSSE/blob/05d95c87b05018d154e33ff9bc74ac5168a1fc53/ReactiveSSE/Classes/EventStream.swift

**Performance:**

I measured using the performance test with release build and it makes around 60% better performance for Strings.

